### PR TITLE
CSP development wss

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -20,6 +20,7 @@ Rails.application.configure do
 
       policy.connect_src :self,
                          # Allow @vite/client to hot reload CSS changes
+                         "wss://#{ENV.fetch('APP_HOST', nil)}",
                          "wss://#{ViteRuby.config.host}"
     else
       policy.default_src :none


### PR DESCRIPTION
Add wss (cable) to the CSRF policy in development. Otherwise cable (Hotwire) won't work in safari, at least in development mode.

![Captura de Pantalla 2022-06-16 a las 14 21 10](https://user-images.githubusercontent.com/24901613/174068510-efa7a2ee-645a-4fc6-b562-6b5be0ab1901.png)

Thanks.
