### PR TITLE
Added namespace to BlockLength AllowedMethods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,7 +115,7 @@ Layout/LineLength:
 ### Metrics
 
 Metrics/BlockLength:
-  AllowedMethods: ['configure', 'content_security_policy', 'task']
+  AllowedMethods: ['configure', 'content_security_policy', 'task', 'namespace']
 
 RSpec/ExampleLength:
   Enabled: false


### PR DESCRIPTION
Added `namespace` to AllowedMethods to fix false detection in the following cases:

```ruby
namespace :plugins do
  desc "Fetch latest revisions"
  task :fetch do
    # ..
  end
 
  desc "Push latest revisions"
  task :push do
    # ..
  end
 
  desc "Cleanup repos"
  task :gc do
    # ..
  end
end
```